### PR TITLE
ci: restrict GITHUB_TOKEN to read-only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `permissions: contents: read` to the test workflow. The workflow only checks out source, sets up Bun, installs dependencies, and runs tests. None of these need write access. Restricting the token scope limits exposure if any action or dependency is compromised.